### PR TITLE
Upgrade to node-gettext 1.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "dependencies": {
     "lodash-node": "2.4.x",
-    "node-gettext": "0.2.x"
+    "node-gettext": "1.x"
   },
   "devDependencies": {
     "cover-child-process": "0.1.x",

--- a/tasks/statici18n.js
+++ b/tasks/statici18n.js
@@ -47,6 +47,7 @@ module.exports = function statici18n(grunt) {
       var content = fs.readFileSync(po);
       gt.addTextdomain(lang, content);
     });
+    gt.addTextdomain('_default', null);
   };
 
   var getLocales = function() {


### PR DESCRIPTION
Which seems a little more strict about locales. They have to be registered, before one can switch to them.

`.textdomain()` will return `false` for an unregistered locale, but we're ignoring the return value.
